### PR TITLE
bump core.async dependency

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,6 @@
+{:deps {org.clojure/clojure {:mvn/version "1.10.0"}
+        org.clojure/tools.logging {:mvn/version "0.4.1"}
+        org.clojure/core.async {:mvn/version "0.4.500"}
+        slingshot {:mvn/version "0.12.2"}
+        clj-http {:mvn/version "3.9.1"}
+        cheshire {:mvn/version "5.8.1"}}}

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/tools.logging "0.4.1"]
-                 [org.clojure/core.async "0.4.490"]
+                 [org.clojure/core.async "0.4.500"]
                  [slingshot "0.12.2"]
                  [clj-http "3.9.1"]
                  [cheshire "5.8.1"]])


### PR DESCRIPTION
thank you for sharing this code! i have had a lot of fun with it! i have added a PR to address the following error I came across:     

 necessary to mitigate macro expanding error that occurs in
     clojure version 1.10.1:
```clojure
     Syntax error macroexpanding clojure.core/refer-clojure at (clojure/core/async.clj:9:1).
     :as - failed: #{:exclude} at: [:exclude :op :quoted-spec :spec]
     :as - failed: #{:only} at: [:only :op :quoted-spec :spec]
     :as - fai led: #{:rename} at: [:rename :op :quoted-spec :spec]
     (quote :as) - failed: #{:exclude} at: [:exclude :op :spec]
     (quote :as) - failed: #{:only} at: [:only :op :spec]
     (quote :as) - failed: #{:rename} at: [:rename :op :spec]
```
Thanks again!